### PR TITLE
Update welcome.css.scss

### DIFF
--- a/Stylesheets for FileCabinet/welcome.css.scss
+++ b/Stylesheets for FileCabinet/welcome.css.scss
@@ -44,7 +44,7 @@
 }
 
 #callouts {
-	background-image: url(image_path("callout_background.jpg"));
+	background-image: image-url("callout_background.jpg");
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: top center;


### PR DESCRIPTION
Method url(image_path("callout_background.jpg")) for background-image was not working on Rails 5.
Changed to background-image: image-url("callout_background.jpg") fixed the problem.
